### PR TITLE
Refactor getVersion to chronoversion

### DIFF
--- a/bump-version.js
+++ b/bump-version.js
@@ -1,12 +1,12 @@
 const fs = require("node:fs");
 const path = require("node:path");
-const { getVersion } = require("./dist/index.js");
+const chronoversion = require("./dist/index.js").default;
 
 /**
  * Updates the version in the package.json and package-lock.json files.
  *
  * @description Reads the current package.json and package-lock.json, retrieves the current version,
- * generates a new version using the getVersion function, and writes the updated
+ * generates a new version using the chronoversion function, and writes the updated
  * version back to both files.
  *
  * @throws {Error} If unable to read or parse package.json or package-lock.json
@@ -38,7 +38,7 @@ function updatePackageVersion() {
   }
 
   const currentVersion = packageJson.version;
-  const newVersion = getVersion(currentVersion);
+  const newVersion = chronoversion(currentVersion);
 
   packageJson.version = newVersion;
   packageLockJson.version = newVersion;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getVersion = getVersion;
-function getVersion(currentVersion) {
+function chronoversion(currentVersion) {
     const now = new Date();
     const currentYear = now.getFullYear();
     const currentMonth = now.getMonth() + 1; // getMonth() returns 0-indexed month
@@ -14,3 +13,4 @@ function getVersion(currentVersion) {
     }
     return `${currentYear}.${currentMonth}.1`;
 }
+exports.default = chronoversion;

--- a/dist/index.test.js
+++ b/dist/index.test.js
@@ -1,7 +1,10 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-const _1 = require(".");
-describe("getVersion", () => {
+const _1 = __importDefault(require("."));
+describe("chronoversion", () => {
     const originalDate = global.Date;
     beforeAll(() => {
         // Mock Date to control the current date
@@ -17,23 +20,23 @@ describe("getVersion", () => {
         global.Date = originalDate;
     });
     test("should return current year and month with version 1 if currentVersion is undefined", () => {
-        expect((0, _1.getVersion)(undefined)).toBe("2025.1.1");
+        expect((0, _1.default)(undefined)).toBe("2025.1.1");
     });
     test("should increment version if currentVersion is from the same year and month", () => {
-        expect((0, _1.getVersion)("2025.1.1")).toBe("2025.1.2");
+        expect((0, _1.default)("2025.1.1")).toBe("2025.1.2");
     });
     test("should reset version if currentVersion is from a different year", () => {
-        expect((0, _1.getVersion)("2024.12.9")).toBe("2025.1.1");
+        expect((0, _1.default)("2024.12.9")).toBe("2025.1.1");
     });
     test("should reset version if currentVersion is from a different month", () => {
-        expect((0, _1.getVersion)("2025.12.9")).toBe("2025.1.1");
+        expect((0, _1.default)("2025.12.9")).toBe("2025.1.1");
     });
     test("should handle versions with more than one digit correctly", () => {
-        expect((0, _1.getVersion)("2025.1.9")).toBe("2025.1.10");
+        expect((0, _1.default)("2025.1.9")).toBe("2025.1.10");
     });
     test("should handle versions with multiple digits correctly", () => {
-        expect((0, _1.getVersion)("2025.1.99")).toBe("2025.1.100");
-        expect((0, _1.getVersion)("2025.1.999")).toBe("2025.1.1000");
+        expect((0, _1.default)("2025.1.99")).toBe("2025.1.100");
+        expect((0, _1.default)("2025.1.999")).toBe("2025.1.1000");
     });
     describe("edge cases", () => {
         test("should handle single digit months correctly", () => {
@@ -45,7 +48,7 @@ describe("getVersion", () => {
                     return new originalDate("2025-02-09T11:55:50Z");
                 }
             };
-            expect((0, _1.getVersion)("2025.1.2")).toBe("2025.2.1");
+            expect((0, _1.default)("2025.1.2")).toBe("2025.2.1");
         });
         test("should handle February 28th in a non-leap year", () => {
             global.Date = class extends Date {
@@ -54,7 +57,7 @@ describe("getVersion", () => {
                     return new originalDate("2025-02-28T11:55:50Z");
                 }
             };
-            expect((0, _1.getVersion)("2025.2.1")).toBe("2025.2.2");
+            expect((0, _1.default)("2025.2.1")).toBe("2025.2.2");
         });
         test("should handle February 29th in a leap year", () => {
             global.Date = class extends Date {
@@ -63,7 +66,7 @@ describe("getVersion", () => {
                     return new originalDate("2024-02-29T11:55:50Z");
                 }
             };
-            expect((0, _1.getVersion)("2024.2.1")).toBe("2024.2.2");
+            expect((0, _1.default)("2024.2.1")).toBe("2024.2.2");
         });
         test("should handle March 1st after February 28th in a non-leap year", () => {
             global.Date = class extends Date {
@@ -72,7 +75,7 @@ describe("getVersion", () => {
                     return new originalDate("2025-03-01T11:55:50Z");
                 }
             };
-            expect((0, _1.getVersion)("2025.2.1")).toBe("2025.3.1");
+            expect((0, _1.default)("2025.2.1")).toBe("2025.3.1");
         });
         test("should handle March 1st after February 29th in a leap year", () => {
             global.Date = class extends Date {
@@ -81,7 +84,7 @@ describe("getVersion", () => {
                     return new originalDate("2024-03-01T11:55:50Z");
                 }
             };
-            expect((0, _1.getVersion)("2024.2.1")).toBe("2024.3.1");
+            expect((0, _1.default)("2024.2.1")).toBe("2024.3.1");
         });
     });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
-import { getVersion } from ".";
+import chronoversion from ".";
 
-describe("getVersion", () => {
+describe("chronoversion", () => {
   const originalDate = global.Date;
 
   beforeAll(() => {
@@ -19,28 +19,28 @@ describe("getVersion", () => {
   });
 
   test("should return current year and month with version 1 if currentVersion is undefined", () => {
-    expect(getVersion(undefined)).toBe("2025.1.1");
+    expect(chronoversion(undefined)).toBe("2025.1.1");
   });
 
   test("should increment version if currentVersion is from the same year and month", () => {
-    expect(getVersion("2025.1.1")).toBe("2025.1.2");
+    expect(chronoversion("2025.1.1")).toBe("2025.1.2");
   });
 
   test("should reset version if currentVersion is from a different year", () => {
-    expect(getVersion("2024.12.9")).toBe("2025.1.1");
+    expect(chronoversion("2024.12.9")).toBe("2025.1.1");
   });
 
   test("should reset version if currentVersion is from a different month", () => {
-    expect(getVersion("2025.12.9")).toBe("2025.1.1");
+    expect(chronoversion("2025.12.9")).toBe("2025.1.1");
   });
 
   test("should handle versions with more than one digit correctly", () => {
-    expect(getVersion("2025.1.9")).toBe("2025.1.10");
+    expect(chronoversion("2025.1.9")).toBe("2025.1.10");
   });
 
   test("should handle versions with multiple digits correctly", () => {
-    expect(getVersion("2025.1.99")).toBe("2025.1.100");
-    expect(getVersion("2025.1.999")).toBe("2025.1.1000");
+    expect(chronoversion("2025.1.99")).toBe("2025.1.100");
+    expect(chronoversion("2025.1.999")).toBe("2025.1.1000");
   });
 
   describe("edge cases", () => {
@@ -54,7 +54,7 @@ describe("getVersion", () => {
         }
       } as DateConstructor;
 
-      expect(getVersion("2025.1.2")).toBe("2025.2.1");
+      expect(chronoversion("2025.1.2")).toBe("2025.2.1");
     });
 
     test("should handle February 28th in a non-leap year", () => {
@@ -65,7 +65,7 @@ describe("getVersion", () => {
         }
       } as DateConstructor;
 
-      expect(getVersion("2025.2.1")).toBe("2025.2.2");
+      expect(chronoversion("2025.2.1")).toBe("2025.2.2");
     });
 
     test("should handle February 29th in a leap year", () => {
@@ -76,7 +76,7 @@ describe("getVersion", () => {
         }
       } as DateConstructor;
 
-      expect(getVersion("2024.2.1")).toBe("2024.2.2");
+      expect(chronoversion("2024.2.1")).toBe("2024.2.2");
     });
 
     test("should handle March 1st after February 28th in a non-leap year", () => {
@@ -87,7 +87,7 @@ describe("getVersion", () => {
         }
       } as DateConstructor;
 
-      expect(getVersion("2025.2.1")).toBe("2025.3.1");
+      expect(chronoversion("2025.2.1")).toBe("2025.3.1");
     });
 
     test("should handle March 1st after February 29th in a leap year", () => {
@@ -98,7 +98,7 @@ describe("getVersion", () => {
         }
       } as DateConstructor;
 
-      expect(getVersion("2024.2.1")).toBe("2024.3.1");
+      expect(chronoversion("2024.2.1")).toBe("2024.3.1");
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export function getVersion(currentVersion?: string): string {
+function chronoversion(currentVersion?: string): string {
   const now = new Date();
   const currentYear = now.getFullYear();
   const currentMonth = now.getMonth() + 1; // getMonth() returns 0-indexed month
@@ -15,3 +15,5 @@ export function getVersion(currentVersion?: string): string {
 
   return `${currentYear}.${currentMonth}.1`;
 }
+
+export default chronoversion;


### PR DESCRIPTION
Rename the `getVersion` function to `chronoversion` and update all references accordingly. This change improves clarity and consistency in the codebase.

## Summary by Sourcery

Rename the `getVersion` function to `chronoversion`.

Enhancements:
- Improve clarity and consistency in the codebase.

Chores:
- Update all references to the renamed function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed version generation function from `getVersion` to `chronoversion`
	- Updated function to be the default export in the module

- **Chores**
	- Updated import and usage of version generation function across project files
	- Maintained existing version generation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->