### PR TITLE
Bump version to 2025.1.3 and update postrelease script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chronoversion",
-  "version": "2025.1.2",
+  "version": "2025.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronoversion",
-  "version": "2025.1.2",
+  "version": "2025.1.3",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc --outDir dist",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bump-version": "node bump-version.js",
     "prerelease": "git diff-index --quiet HEAD && npm audit",
     "release": "npm run lint && npm run generate-todo && npm run build && npm run test && npm run bump-version",
-    "postrelease": "git add package.json && git commit -m \"chore: bump version\" && git push && git push --tags",
+    "postrelease": "git add package.json && git add package-lock.json && git commit -m \"chore: bump version\" && git push && git push --tags",
     "lint": "npx @biomejs/biome check ./src bump-version.js",
     "lint:fix": "npm run lint -- --write",
     "generate-todo": "leasot -x --reporter markdown 'src/**/*.{js,jsx,ts,tsx,css}' > TODO.md",


### PR DESCRIPTION
Update the version number to 2025.1.3 and modify the postrelease script to include `package-lock.json` in the commit.

## Summary by Sourcery

Bump version to 2025.1.3 and include `package-lock.json` in the postrelease commit.

Enhancements:
- Bump version to 2025.1.3.

Chores:
- Update the postrelease script to include `package-lock.json` in the commit.